### PR TITLE
Make package julia 0.7 compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.jl.*.cov
 *.jl.mem
 deps/deps.jl
+docs/site
+new_file_with_tabs.jl
+new_file_with_wrong_license_header.jl

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: julia
+os:
+  - linux
+  - osx
+julia:
+  - 0.6
+  - 0.7
+  - nightly
+#matrix:
+#  allow_failures:
+#    - julia: 0.7
+#    - julia: nightly
+#  fast_finish: true
+after_success:
+    - julia --color=yes -e 'using PkgTestSuite; deploy()'

--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 # PkgTestSuite.jl
 
-Standard test suite for packages under JuliaFEM
+[![Build Status](https://travis-ci.org/JuliaFEM/PkgTestSuite.jl.svg?branch=master)](https://travis-ci.org/JuliaFEM/PkgTestSuite.jl)
+
+Standard test suite for packages under JuliaFEM organization. The purpose of
+this package is to
+1. avoid unnecessary boilerplate code of setting up new packages, and
+2. provide a standardized way to test that package matches to JuliaFEM standards.
 
 Usage from command line:
 
 ```julia
 julia> using PkgTestSuite
-julia> test(pkg)
-julia> deploy(pkg)
+julia> test(pkg_name)
+julia> deploy(pkg_name)
 ```
 
-`pkg` is the name of the package. If running `deploy()` from command line, documentation is generated to `docs/site`.
+If running `deploy()` from command line, documentation is generated to `docs/site`.
 
 Usage from Travis-CI:
 
@@ -25,10 +30,10 @@ after_success:
 ```
 
 Default sequence is:
-1. check that all source files contain licence string using CheckHeader.jl
-2. check that no tabs are used in source files using CheckTabs.jl
+1. check that all source files contain licence string
+2. check that no tabs are used in source files
 3. check code syntax using Lint.jl
-4. check documentation using Documenter.jl
+4. generate documentation of package using Documenter.jl
 5. run all unit tests
 6. deploy documentation to juliafem.github.io and coverage report to coveralls.io
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,0 +1,5 @@
+julia 0.6
+Coverage
+Documenter
+Lint
+TimerOutputs

--- a/docs/deploy.jl
+++ b/docs/deploy.jl
@@ -1,0 +1,10 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/PkgTestSuite.jl/blob/master/LICENSE
+
+using Documenter
+
+deploydocs(
+    repo = "github.com/JuliaFEM/PkgTestSuite.jl.git",
+    julia = "0.7",
+    deps = nothing,
+    make = nothing)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,12 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/PkgTestSuite.jl/blob/master/LICENSE
+
+using Documenter
+using PkgTestSuite
+
+makedocs(modules=[PkgTestSuite],
+         format = :html,
+         checkdocs = :all,
+         sitename = "PkgTestSuite.jl",
+         pages = ["index.md"]
+        )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,10 @@
+# PkgTestSuite.jl
+
+Package contains a standardized testing routines for packages under JuliaFEM
+organization.
+
+```@meta
+DocTestSetup = quote
+    using PkgTestSuite
+end
+```

--- a/src/checkheader.jl
+++ b/src/checkheader.jl
@@ -1,0 +1,82 @@
+# This file is a part of JuliaFEM. 
+# License is MIT: see https://github.com/JuliaFEM/PkgTestSuite.jl/blob/master/LICENSE
+
+"""
+    read_header(fid)
+
+Read header from file content.
+
+Searches "part of" and "license" lines using regular expression
+from file header.
+"""
+function read_header(fd)
+    lines = readlines(fd)
+    header_comment = true
+    header_lines = []
+    regex_strings = [r"(This file is a part of \w+)",
+                     r"(License is [\s\w.]+: [\w\W\s]+)"]
+    no_empty_lines = filter(x->x != "", lines)
+    for line in no_empty_lines
+        !startswith(line, "#") && break
+        for each in regex_strings
+            found = match(each, line)
+            found != nothing && push!(header_lines, found[1])
+        end
+    end
+    return header_lines
+end
+
+"""
+    checkheader(pkg_name; source_dirs=["src", "test"])
+
+Check headers of files.
+
+Reads all julia source files from source_dirs and compares
+that file license header matches the one found from packages
+main file license header.
+"""
+function checkheader(package::String; source_dirs=["src", "test"])
+    pkg_dir = Pkg.dir(package)
+    main_file = joinpath(pkg_dir, "src", package * ".jl")
+    main_header = open(read_header, main_file)
+    nlines = length(main_header)
+    info("Found header from $package.jl:")
+    info("------------------------------")
+    for j=1:nlines
+        info(main_header[j])
+    end
+    info("------------------------------")
+    hasdiff = false
+    nfiles = 0
+    for dir in source_dirs
+        isdir(joinpath(pkg_dir, dir)) || continue
+        all_files = readdir(joinpath(pkg_dir, dir))
+        only_julia_files = filter(x->endswith(x, ".jl"), all_files)
+        for file_name in only_julia_files
+            nfiles += 1
+            src_file = joinpath(pkg_dir, dir, file_name)
+            header_compare = open(read_header, src_file)
+            lines_in_compare = length(header_compare)
+            if lines_in_compare != nlines
+                info(header_compare, " ", file_name)
+                warn("The number of header lines differs in file $dir/$file_name:")
+                hasdiff = true
+                continue
+            end
+            for j=1:nlines
+                if main_header[j] != header_compare[j]
+                    warn("Header content difference in file $dir/$file_name:")
+                    hasdiff = true
+                    break
+                end
+            end
+        end
+    end
+    if hasdiff
+        error("Found header differences between source files!")
+    end
+    info("Header is same in all $nfiles files.")
+    return true
+end
+
+export checkheader

--- a/src/checktabs.jl
+++ b/src/checktabs.jl
@@ -1,0 +1,37 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/PkgTestSuite.jl/blob/master/LICENSE
+
+"""
+    checktabs(pkg_name)
+
+Read all julia source files of package and check that no tabulators are found
+from files.
+"""
+function checktabs(package::String)
+    pkg_dir = Pkg.dir(package)
+    dirs = ["src", "test"]
+    hastabs = false
+    nfiles = 0
+    for dir in dirs
+        isdir(joinpath(pkg_dir, dir)) || continue
+        all_files = readdir(joinpath(pkg_dir, dir))
+        for file_name in all_files
+            endswith(file_name, ".jl") || continue
+            nfiles += 1
+            src_file = joinpath(pkg_dir, dir, file_name)
+            src_lines = readlines(open(src_file))
+            for (i, line) in enumerate(src_lines)
+                if '\t' in line
+                    warn("use of tabulator found at file $file_name, at line $i:")
+                    println(line)
+                    hastabs = true
+                end
+            end
+        end
+    end
+    if hastabs
+        error("Source files has tabs. Please fix files.")
+    end
+    info("No use of tabulator found from $nfiles source files.")
+    return true
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,13 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/PkgTestSuite.jl/blob/master/LICENSE
+
+using PkgTestSuite
+using Base.Test
+
+@testset "test checkheader" begin
+    include("test_checkheader.jl")
+end
+
+@testset "test checktabs" begin 
+    include("test_checktabs.jl")
+end

--- a/test/test_checkheader.jl
+++ b/test/test_checkheader.jl
@@ -1,0 +1,24 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/PkgTestSuite.jl/blob/master/LICENSE
+
+using PkgTestSuite: checkheader
+using Base.Test
+
+new_file_path = Pkg.dir("PkgTestSuite", "src", "new_file_with_wrong_license_header.jl")
+if isfile(new_file_path)
+    rm(new_file_path)
+end
+
+@test checkheader("PkgTestSuite")
+
+fid = open(new_file_path, "w")
+write(fid, """
+# This file is not a part of JuliaFEM.
+# License is not MIT: don't see https://github.com/JuliaFEM/PkgTestSuite.jl/blob/master/LICENSE
+
+function foo()
+    return 1
+end
+""")
+close(fid)
+@test_throws Exception checkheader("PkgTestSuite")

--- a/test/test_checktabs.jl
+++ b/test/test_checktabs.jl
@@ -1,0 +1,24 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/PkgTestSuite.jl/blob/master/LICENSE
+
+using PkgTestSuite: checktabs
+using Base.Test
+
+new_file_path = Pkg.dir("PkgTestSuite", "src", "new_file_with_tabs.jl")
+if isfile(new_file_path)
+    rm(new_file_path)
+end
+
+@test checktabs("PkgTestSuite")
+
+fid = open(new_file_path, "w")
+write(fid, """
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/PkgTestSuite.jl/blob/master/LICENSE
+
+function foo()
+\treturn 1
+end
+""")
+close(fid)
+@test_throws Exception checktabs("PkgTestSuite")


### PR DESCRIPTION
- Include files from `CheckHeader.jl` and `CheckTabs.jl`.
- Activate Travis-CI.
- Use Documenter.jl to generate documentation.